### PR TITLE
UPnP better error handling

### DIFF
--- a/Lesson 2/upnp-basics/after/task/getData.js
+++ b/Lesson 2/upnp-basics/after/task/getData.js
@@ -6,7 +6,7 @@ class getData {
 
     // get the list of available IP addresses from the task state
     // nodeList is an object with key-value pairs in the form stakingKey: ipAddress
-    const nodeList = taskState.ip_address_list;
+    const nodeList = taskState.ip_address_list ?? {};
 
     // return just the IP addresses
     return Object.values(IPAddressObj);
@@ -16,6 +16,9 @@ class getData {
   }
 
   async getRandomNodeEndpoint(IPAddressArray) {
+    if (!IPAddressArray || IPAddressArray.length === 0) {
+      throw new Error('No IP addresses available');
+    }
    //  Choose a random index
     const randomIndex = Math.floor(Math.random() * IPAddressArray.length);
    //  Return the IP address stored at the random index position


### PR DESCRIPTION
Added a more descriptive error for the cases where there are no IP addresses to check. Also made sure that getAddressArray doesn't throw an error when the IP address list is empty, as the error you get is related to task state.