### PR TITLE
hide information on limiting number of audits

### DIFF
--- a/Lesson 4/PartI.md
+++ b/Lesson 4/PartI.md
@@ -150,8 +150,8 @@ module.exports = isValidFile;
 
 This audit combines elements of the UPnP and Simple Crawler tasks - it verifies that a file exists and also checks that the contents of the file match the expected format.
 
-### Controlling the Number of Auditing Nodes
+<!-- ### Controlling the Number of Auditing Nodes
 
-In some cases, you may want to set the number of nodes you'd like to perform an audit each round. For this, you can add custom logic to the `validateAndVoteOnNodes()` function. Note that unlike other functions we've worked with before, this one is located in [`NamespaceWrapper`](./caesar-task/_koiiNode/koiiNode.js#L657). You can see an example from the Twitter Archive task [here](https://gitlab.com/koii-network/dev-blue/task-X/-/blob/main/namespaceWrapper.js?ref_type=heads#L579-592)
+In some cases, you may want to set the number of nodes you'd like to perform an audit each round. For this, you can add custom logic to the `validateAndVoteOnNodes()` function. Note that unlike other functions we've worked with before, this one is located in `NamespaceWrapper` You can see an example from the Twitter Archive task [here](https://github.com/koii-network/task-x/blob/main/namespaceWrapper.js?ref_type=heads#L579-592) -->
 
 Now let's take a look at distribution concepts in [Part II](./PartII.md)


### PR DESCRIPTION
Temporary solution to deal with #98. The information we provided doesn't work anymore and can't be quickly updated since namespaceWrapper is now a package.