### PR TITLE
Reduce bounties and space

### DIFF
--- a/Lesson 1/EZ-testing-task/config-task.yml
+++ b/Lesson 1/EZ-testing-task/config-task.yml
@@ -20,9 +20,11 @@ submission_window: 350
 # minimum_stake_amount: The minimum amount of KOII that a user must stake in order to participate in the task
 minimum_stake_amount: 1.9
 
-# total_bounty_amount cannot be grater than bounty_amount_per_round
-# total bounty_amount: The total bounty amount that will be distributed to the task. (Not accepted in case of update task)
+
+# total_bounty_amount: The total bounty amount that will be distributed to the task. (Does not work when updating task)
 total_bounty_amount: 10
+# total_bounty_amount: the maximum amount of KOII that can be distributed each round
+# bounty_amount_per_round cannot be greater than total_bounty_amount
 bounty_amount_per_round: 0.1
 
 # allowed_failed_distributions: Number of times re-submission is allowed for the distribution list in case of an audit.

--- a/Lesson 1/EZ-testing-task/config-task.yml
+++ b/Lesson 1/EZ-testing-task/config-task.yml
@@ -31,7 +31,9 @@ bounty_amount_per_round: 0.1
 allowed_failed_distributions: 3
 
 # space: Space in MBs for the account size, that holds the task data.
-space: 1
+# for testing tasks this can be set to 0.1 but
+# for production it should be set to at least 1
+space: 0.1
 
 # Note that the value field in RequirementTag is optional, so it is up to you to include it or not based on your use case.
 # To add more global variables and task variables, please refer the type,value, description format shown below

--- a/Lesson 2/file-sharing/after/config-task.yml
+++ b/Lesson 2/file-sharing/after/config-task.yml
@@ -30,7 +30,9 @@ bounty_amount_per_round: 0.1
 allowed_failed_distributions: 3
 
 # space: Space in MBs for the account size, that holds the task data.
-space: 1
+# for testing tasks this can be set to 0.1 but
+# for production it should be set to at least 1
+space: 0.1
 
 # Note that the value field in RequirementTag is optional, so it is up to you to include it or not based on your use case.
 # To add more global variables and task variables, please refer the type,value, description format shown below

--- a/Lesson 2/file-sharing/after/config-task.yml
+++ b/Lesson 2/file-sharing/after/config-task.yml
@@ -20,9 +20,10 @@ submission_window: 350
 # minimum_stake_amount: The minimum amount of KOII that a user must stake in order to participate in the task
 minimum_stake_amount: 1.9
 
-# total_bounty_amount cannot be grater than bounty_amount_per_round
-# total bounty_amount: The total bounty amount that will be distributed to the task. (Not accepted in case of update task)
+# total_bounty_amount: The total bounty amount that will be distributed to the task. (Does not work when updating task)
 total_bounty_amount: 10
+# total_bounty_amount: the maximum amount of KOII that can be distributed each round
+# bounty_amount_per_round cannot be greater than total_bounty_amount
 bounty_amount_per_round: 0.1
 
 # allowed_failed_distributions: Number of times re-submission is allowed for the distribution list in case of an audit.

--- a/Lesson 2/file-sharing/after/config-task.yml
+++ b/Lesson 2/file-sharing/after/config-task.yml
@@ -22,8 +22,8 @@ minimum_stake_amount: 1.9
 
 # total_bounty_amount cannot be grater than bounty_amount_per_round
 # total bounty_amount: The total bounty amount that will be distributed to the task. (Not accepted in case of update task)
-total_bounty_amount: 100
-bounty_amount_per_round: 100
+total_bounty_amount: 10
+bounty_amount_per_round: 0.1
 
 # allowed_failed_distributions: Number of times re-submission is allowed for the distribution list in case of an audit.
 allowed_failed_distributions: 3

--- a/Lesson 2/file-sharing/before/config-task.yml
+++ b/Lesson 2/file-sharing/before/config-task.yml
@@ -30,7 +30,9 @@ bounty_amount_per_round: 0.1
 allowed_failed_distributions: 3
 
 # space: Space in MBs for the account size, that holds the task data.
-space: 1
+# for testing tasks this can be set to 0.1 but
+# for production it should be set to at least 1
+space: 0.1
 
 # Note that the value field in RequirementTag is optional, so it is up to you to include it or not based on your use case.
 # To add more global variables and task variables, please refer the type,value, description format shown below

--- a/Lesson 2/file-sharing/before/config-task.yml
+++ b/Lesson 2/file-sharing/before/config-task.yml
@@ -20,9 +20,10 @@ submission_window: 350
 # minimum_stake_amount: The minimum amount of KOII that a user must stake in order to participate in the task
 minimum_stake_amount: 1.9
 
-# total_bounty_amount cannot be grater than bounty_amount_per_round
-# total bounty_amount: The total bounty amount that will be distributed to the task. (Not accepted in case of update task)
+# total_bounty_amount: The total bounty amount that will be distributed to the task. (Does not work when updating task)
 total_bounty_amount: 10
+# total_bounty_amount: the maximum amount of KOII that can be distributed each round
+# bounty_amount_per_round cannot be greater than total_bounty_amount
 bounty_amount_per_round: 0.1
 
 # allowed_failed_distributions: Number of times re-submission is allowed for the distribution list in case of an audit.

--- a/Lesson 2/file-sharing/before/config-task.yml
+++ b/Lesson 2/file-sharing/before/config-task.yml
@@ -22,8 +22,8 @@ minimum_stake_amount: 1.9
 
 # total_bounty_amount cannot be grater than bounty_amount_per_round
 # total bounty_amount: The total bounty amount that will be distributed to the task. (Not accepted in case of update task)
-total_bounty_amount: 100
-bounty_amount_per_round: 100
+total_bounty_amount: 10
+bounty_amount_per_round: 0.1
 
 # allowed_failed_distributions: Number of times re-submission is allowed for the distribution list in case of an audit.
 allowed_failed_distributions: 3

--- a/Lesson 2/upnp-basics/after/config-task.yml
+++ b/Lesson 2/upnp-basics/after/config-task.yml
@@ -30,7 +30,9 @@ bounty_amount_per_round: 0.1
 allowed_failed_distributions: 3
 
 # space: Space in MBs for the account size, that holds the task data.
-space: 1
+# for testing tasks this can be set to 0.1 but
+# for production it should be set to at least 1
+space: 0.1
 
 # Note that the value field in RequirementTag is optional, so it is up to you to include it or not based on your use case.
 # To add more global variables and task variables, please refer the type,value, description format shown below

--- a/Lesson 2/upnp-basics/after/config-task.yml
+++ b/Lesson 2/upnp-basics/after/config-task.yml
@@ -20,9 +20,10 @@ submission_window: 550
 # minimum_stake_amount: The minimum amount of KOII that a user must stake in order to participate in the task
 minimum_stake_amount: 1.9
 
-# total_bounty_amount cannot be grater than bounty_amount_per_round
-# total bounty_amount: The total bounty amount that will be distributed to the task. (Not accepted in case of update task)
+# total_bounty_amount: The total bounty amount that will be distributed to the task. (Does not work when updating task)
 total_bounty_amount: 10
+# total_bounty_amount: the maximum amount of KOII that can be distributed each round
+# bounty_amount_per_round cannot be greater than total_bounty_amount
 bounty_amount_per_round: 0.1
 
 # allowed_failed_distributions: Number of times re-submission is allowed for the distribution list in case of an audit.

--- a/Lesson 2/upnp-basics/after/config-task.yml
+++ b/Lesson 2/upnp-basics/after/config-task.yml
@@ -22,8 +22,8 @@ minimum_stake_amount: 1.9
 
 # total_bounty_amount cannot be grater than bounty_amount_per_round
 # total bounty_amount: The total bounty amount that will be distributed to the task. (Not accepted in case of update task)
-total_bounty_amount: 100
-bounty_amount_per_round: 100
+total_bounty_amount: 10
+bounty_amount_per_round: 0.1
 
 # allowed_failed_distributions: Number of times re-submission is allowed for the distribution list in case of an audit.
 allowed_failed_distributions: 3

--- a/Lesson 2/upnp-basics/before/config-task.yml
+++ b/Lesson 2/upnp-basics/before/config-task.yml
@@ -30,7 +30,9 @@ bounty_amount_per_round: 0.1
 allowed_failed_distributions: 3
 
 # space: Space in MBs for the account size, that holds the task data.
-space: 1
+# for testing tasks this can be set to 0.1 but
+# for production it should be set to at least 1
+space: 0.1
 
 # Note that the value field in RequirementTag is optional, so it is up to you to include it or not based on your use case.
 # To add more global variables and task variables, please refer the type,value, description format shown below

--- a/Lesson 2/upnp-basics/before/config-task.yml
+++ b/Lesson 2/upnp-basics/before/config-task.yml
@@ -20,9 +20,10 @@ submission_window: 350
 # minimum_stake_amount: The minimum amount of KOII that a user must stake in order to participate in the task
 minimum_stake_amount: 1.9
 
-# total_bounty_amount cannot be grater than bounty_amount_per_round
-# total bounty_amount: The total bounty amount that will be distributed to the task. (Not accepted in case of update task)
+# total_bounty_amount: The total bounty amount that will be distributed to the task. (Does not work when updating task)
 total_bounty_amount: 10
+# total_bounty_amount: the maximum amount of KOII that can be distributed each round
+# bounty_amount_per_round cannot be greater than total_bounty_amount
 bounty_amount_per_round: 0.1
 
 # allowed_failed_distributions: Number of times re-submission is allowed for the distribution list in case of an audit.

--- a/Lesson 2/upnp-basics/before/config-task.yml
+++ b/Lesson 2/upnp-basics/before/config-task.yml
@@ -22,8 +22,8 @@ minimum_stake_amount: 1.9
 
 # total_bounty_amount cannot be grater than bounty_amount_per_round
 # total bounty_amount: The total bounty amount that will be distributed to the task. (Not accepted in case of update task)
-total_bounty_amount: 100
-bounty_amount_per_round: 100
+total_bounty_amount: 10
+bounty_amount_per_round: 0.1
 
 # allowed_failed_distributions: Number of times re-submission is allowed for the distribution list in case of an audit.
 allowed_failed_distributions: 3

--- a/Lesson 3/PartII.md
+++ b/Lesson 3/PartII.md
@@ -36,9 +36,9 @@ minimum_stake_amount: 1.9
 
 # The total bounty amount that will be distributed to the task
 ## when updating a task, this cannot be changed
-total_bounty_amount: 100
+total_bounty_amount: 10
 # must be less than or equal to total_bounty_amount
-bounty_amount_per_round: 100
+bounty_amount_per_round: 0.1
 
 # allowed_failed_distributions: Number of times re-submission is allowed for the distribution list in case of an audit.
 allowed_failed_distributions: 3

--- a/Lesson 3/PartII.md
+++ b/Lesson 3/PartII.md
@@ -44,7 +44,9 @@ bounty_amount_per_round: 0.1
 allowed_failed_distributions: 3
 
 # space: Space in MBs for the account size, that holds the task data.
-space: 1
+# for testing tasks this can be set to 0.1 but
+# for production it should be set to at least 1
+space: 0.1
 
 # Note that the value field in RequirementTag is optional, so it is up to you to include it or not based on your use case.
 # To add more global variables and task variables, please refer the type, value, description format shown below

--- a/Lesson 3/simple-crawler/after/config-task.yml
+++ b/Lesson 3/simple-crawler/after/config-task.yml
@@ -21,10 +21,10 @@ submission_window: 350
 
 minimum_stake_amount: 1.9
 
-# total_bounty_amount cannot be grater than bounty_amount_per_round
-# total bounty is not accepted in case of update task
+# total_bounty_amount: The total bounty amount that will be distributed to the task. (Does not work when updating task)
 total_bounty_amount: 10
-
+# total_bounty_amount: the maximum amount of KOII that can be distributed each round
+# bounty_amount_per_round cannot be greater than total_bounty_amount
 bounty_amount_per_round: 0.1
 
 #Number of times allowed to re-submit the distribution  list in case the distribution list is audited

--- a/Lesson 3/simple-crawler/after/config-task.yml
+++ b/Lesson 3/simple-crawler/after/config-task.yml
@@ -23,9 +23,9 @@ minimum_stake_amount: 1.9
 
 # total_bounty_amount cannot be grater than bounty_amount_per_round
 # total bounty is not accepted in case of update task
-total_bounty_amount: 15
+total_bounty_amount: 10
 
-bounty_amount_per_round: 0.01
+bounty_amount_per_round: 0.1
 
 #Number of times allowed to re-submit the distribution  list in case the distribution list is audited
 allowed_failed_distributions: 3

--- a/Lesson 3/simple-crawler/before/config-task.yml
+++ b/Lesson 3/simple-crawler/before/config-task.yml
@@ -30,7 +30,9 @@ bounty_amount_per_round: 0.1
 allowed_failed_distributions: 3
 
 # space: Space in MBs for the account size, that holds the task data.
-space: 1
+# for testing tasks this can be set to 0.1 but
+# for production it should be set to at least 1
+space: 0.1
 
 # Note that the value field in RequirementTag is optional, so it is up to you to include it or not based on your use case.
 # To add more global variables and task variables, please refer the type,value, description format shown below

--- a/Lesson 3/simple-crawler/before/config-task.yml
+++ b/Lesson 3/simple-crawler/before/config-task.yml
@@ -20,9 +20,10 @@ submission_window: 350
 # minimum_stake_amount: The minimum amount of KOII that a user must stake in order to participate in the task
 minimum_stake_amount: 1.9
 
-# total_bounty_amount cannot be grater than bounty_amount_per_round
-# total bounty_amount: The total bounty amount that will be distributed to the task. (Not accepted in case of update task)
+# total_bounty_amount: The total bounty amount that will be distributed to the task. (Does not work when updating task)
 total_bounty_amount: 10
+# total_bounty_amount: the maximum amount of KOII that can be distributed each round
+# bounty_amount_per_round cannot be greater than total_bounty_amount
 bounty_amount_per_round: 0.1
 
 # allowed_failed_distributions: Number of times re-submission is allowed for the distribution list in case of an audit.

--- a/Lesson 3/simple-crawler/before/config-task.yml
+++ b/Lesson 3/simple-crawler/before/config-task.yml
@@ -22,8 +22,8 @@ minimum_stake_amount: 1.9
 
 # total_bounty_amount cannot be grater than bounty_amount_per_round
 # total bounty_amount: The total bounty amount that will be distributed to the task. (Not accepted in case of update task)
-total_bounty_amount: 100
-bounty_amount_per_round: 100
+total_bounty_amount: 10
+bounty_amount_per_round: 0.1
 
 # allowed_failed_distributions: Number of times re-submission is allowed for the distribution list in case of an audit.
 allowed_failed_distributions: 3

--- a/Lesson 4/caesar-task/after/config-task.yml
+++ b/Lesson 4/caesar-task/after/config-task.yml
@@ -30,7 +30,9 @@ bounty_amount_per_round: 0.1
 allowed_failed_distributions: 3
 
 # space: Space in MBs for the account size, that holds the task data.
-space: 1
+# for testing tasks this can be set to 0.1 but
+# for production it should be set to at least 1
+space: 0.1
 
 # Note that the value field in RequirementTag is optional, so it is up to you to include it or not based on your use case.
 # To add more global variables and task variables, please refer the type,value, description format shown below

--- a/Lesson 4/caesar-task/after/config-task.yml
+++ b/Lesson 4/caesar-task/after/config-task.yml
@@ -20,9 +20,10 @@ submission_window: 350
 # minimum_stake_amount: The minimum amount of KOII that a user must stake in order to participate in the task
 minimum_stake_amount: 1.9
 
-# total_bounty_amount cannot be grater than bounty_amount_per_round
-# total bounty_amount: The total bounty amount that will be distributed to the task. (Not accepted in case of update task)
+# total_bounty_amount: The total bounty amount that will be distributed to the task. (Does not work when updating task)
 total_bounty_amount: 10
+# total_bounty_amount: the maximum amount of KOII that can be distributed each round
+# bounty_amount_per_round cannot be greater than total_bounty_amount
 bounty_amount_per_round: 0.1
 
 # allowed_failed_distributions: Number of times re-submission is allowed for the distribution list in case of an audit.

--- a/Lesson 4/caesar-task/after/config-task.yml
+++ b/Lesson 4/caesar-task/after/config-task.yml
@@ -22,8 +22,8 @@ minimum_stake_amount: 1.9
 
 # total_bounty_amount cannot be grater than bounty_amount_per_round
 # total bounty_amount: The total bounty amount that will be distributed to the task. (Not accepted in case of update task)
-total_bounty_amount: 100
-bounty_amount_per_round: 100
+total_bounty_amount: 10
+bounty_amount_per_round: 0.1
 
 # allowed_failed_distributions: Number of times re-submission is allowed for the distribution list in case of an audit.
 allowed_failed_distributions: 3

--- a/Lesson 4/caesar-task/before/config-task.yml
+++ b/Lesson 4/caesar-task/before/config-task.yml
@@ -30,7 +30,9 @@ bounty_amount_per_round: 0.1
 allowed_failed_distributions: 3
 
 # space: Space in MBs for the account size, that holds the task data.
-space: 1
+# for testing tasks this can be set to 0.1 but
+# for production it should be set to at least 1
+space: 0.1
 
 # Note that the value field in RequirementTag is optional, so it is up to you to include it or not based on your use case.
 # To add more global variables and task variables, please refer the type,value, description format shown below

--- a/Lesson 4/caesar-task/before/config-task.yml
+++ b/Lesson 4/caesar-task/before/config-task.yml
@@ -20,9 +20,10 @@ submission_window: 350
 # minimum_stake_amount: The minimum amount of KOII that a user must stake in order to participate in the task
 minimum_stake_amount: 1.9
 
-# total_bounty_amount cannot be grater than bounty_amount_per_round
-# total bounty_amount: The total bounty amount that will be distributed to the task. (Not accepted in case of update task)
+# total_bounty_amount: The total bounty amount that will be distributed to the task. (Does not work when updating task)
 total_bounty_amount: 10
+# total_bounty_amount: the maximum amount of KOII that can be distributed each round
+# bounty_amount_per_round cannot be greater than total_bounty_amount
 bounty_amount_per_round: 0.1
 
 # allowed_failed_distributions: Number of times re-submission is allowed for the distribution list in case of an audit.

--- a/Lesson 4/caesar-task/before/config-task.yml
+++ b/Lesson 4/caesar-task/before/config-task.yml
@@ -22,8 +22,8 @@ minimum_stake_amount: 1.9
 
 # total_bounty_amount cannot be grater than bounty_amount_per_round
 # total bounty_amount: The total bounty amount that will be distributed to the task. (Not accepted in case of update task)
-total_bounty_amount: 100
-bounty_amount_per_round: 100
+total_bounty_amount: 10
+bounty_amount_per_round: 0.1
 
 # allowed_failed_distributions: Number of times re-submission is allowed for the distribution list in case of an audit.
 allowed_failed_distributions: 3


### PR DESCRIPTION
Reduce the bounties and space in all the tasks to their minimum values so if people deploy without editing the yaml file, they don't waste KOII.

Closes #114 